### PR TITLE
Some shells disable parsing backslash in echo statements by default

### DIFF
--- a/blcheck
+++ b/blcheck
@@ -307,6 +307,10 @@ if [ $# -eq 0 ]; then
 fi
 TARGET=$1
 
+# Some shells disable parsing backslash in echo statements by default
+# Set the flag to enable echo to behave consistently across platforms
+shopt -s xpg_echo
+
 # Get the command we will use: dig or host
 CMD_DIG=$(which dig)
 CMD_HOST=$(which host)


### PR DESCRIPTION
This branch sets the flag to enable echo to behave consistently across platforms