### PR TITLE
Changing to bash because of bashisms

### DIFF
--- a/blcheck
+++ b/blcheck
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # MIT License
 #


### PR DESCRIPTION
#8, #12 and #13 introduced bashisms (```[[``` and ```shopt```), so either drop them or change the shebang I guess!