### PR TITLE
Fixed broken option -l

### DIFF
--- a/blcheck
+++ b/blcheck
@@ -295,7 +295,7 @@ HELP
 #~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ }
 
 # Parse the params
-while getopts :vqphcld: arg; do
+while getopts :vqphcl:d: arg; do
     case "$arg" in
         d) DNSSERVER=$OPTARG;;
         l) loadBlacklists $OPTARG;;


### PR DESCRIPTION
loadBlacklists() was not working since $OPTARG was empty... this was fixed by properly declaring 'getopts' option l as option l: with a semi colon after.