### PR TITLE
added support for DNSWL and URIBL and optional result filter

### DIFF
--- a/blcheck
+++ b/blcheck
@@ -44,7 +44,6 @@
 
     # Blacklists to check
     CONF_BLACKLISTS="
-        whitelist.rbl.ispa.at
         t3direct.dnsbl.net.au
         ucepn.dnsbl.net.au
         wpbl.dnsbl.net.au
@@ -55,7 +54,6 @@
         spambot.bls.digibase.ca
         probes.dnsbl.net.auproxy.bl.gweep.ca
         rbl2.triumf.ca
-        wbl.triumf.ca
         ipbl.zeustracker.abuse.ch
         uribl.zeustracker.abuse.ch
         spamrbl.imp.ch
@@ -107,12 +105,10 @@
         dnsbl.forefront.microsoft.com
         bl.mipspace.com
         bl.nordspam.com
-        dbl.nordspam.com
         bl.nszones.com
         dyn.nszones.com
         sbl.nszones.com
         ubl.nszones.com
-        wl.nszones.com
         safe.dnsbl.prs.proofpoint.com
         rbl.realtimeblacklist.com
         mailsl.dnsbl.rjek.com
@@ -122,7 +118,6 @@
         reputation-domain.rbl.scrolloutf1.com
         reputation-ip.rbl.scrolloutf1.com
         reputation-ns.rbl.scrolloutf1.com
-        score.senderscore.com
         bl.score.senderscore.com
         feb.spamlab.com
         rbl.spamlab.com
@@ -133,20 +128,16 @@
         spam.spamrats.com
         rbl.suresupport.com
         psbl.surriel.com
-        whitelist.surriel.com
         bl.tiopan.com
-        dbl.tiopan.com
         ubl.unsubscore.com
         black.uribl.com
         grey.uribl.com
         multi.uribl.com
         red.uribl.com
-        white.uribl.com
         spam.dnsbl.anonmails.de
         bl.blocklist.de
         dnsbl.darklist.de
         dnsbl.inps.de
-        dnswl.inps.de
         admin.bl.kundenserver.de
         relays.bl.kundenserver.de
         schizo-bl.kundenserver.de
@@ -159,8 +150,6 @@
         spamsources.fabel.dk
         st.technovision.dk
         dnsbl.abyan.es
-        eswlrev.dnsbl.rediris.es
-        mtawlrev.dnsbl.rediris.es
         dnsbl.isx.fr
         all.spam-rbl.fr
         pofon.foobar.hu
@@ -213,7 +202,6 @@
         dnsbl.mailshell.net
         bl.mailspike.net
         rep.mailspike.net
-        wl.mailspike.net
         z.mailspike.net
         ix.dnsbl.manitu.net
         combined.rbl.msrbl.net
@@ -275,10 +263,8 @@
         urired.spameatingmonkey.net
         bsb.spamlookup.net
         dnsbl.spfbl.net
-        dnswl.spfbl.net
         score.spfbl.net
         bl.suomispam.net
-        dbl.suomispam.net
         gl.suomispam.net
         dob.sibl.support-intelligence.net
         srn.surgate.net
@@ -300,7 +286,6 @@
         bitonly.dnsbl.bit.nl
         virbl.bit.nl
         blacklist.sci.kun.nl
-        whitelist.sci.kun.nl
         blackholes.tepucom.nl
         bl.konstant.no
         bl.0spam.org
@@ -317,8 +302,6 @@
         query.bondedsender.org
         dnsblchile.org
         dnsrbl.org
-        dwl.dnswl.org
-        list.dnswl.org
         bl.drmx.org
         dnsbl.dronebl.org
         rbl.efnet.org
@@ -344,12 +327,9 @@
         public.sarbl.org
         rbl.schulte.org
         sbl.spamdown.org
-        dbl.spamhaus.org
-        vouch.dwl.spamhaus.org
         pbl.spamhaus.org
         sbl.spamhaus.org
         sbl-xbl.spamhaus.org
-        swl.spamhaus.org
         xbl.spamhaus.org
         zen.spamhaus.org
         abuse.surbl.org
@@ -360,7 +340,6 @@
         opm.tornevall.org
         free.v4bl.org
         ip.v4bl.org
-        ips.whitelisted.org
         dnsbl.calivent.com.pe
         forbidden.icm.edu.pl
         dyn.rbl.polspam.pl
@@ -390,7 +369,34 @@
 
         # the following blacklists only take domain names (not IPs)
         # no solution to that, yet
-        # dbl.spamhaus.org
+    CONF_DOMAINLISTS="
+        dbl.nordspam.com
+        dbl.tiopan.com
+        dbl.suomispam.net
+        dbl.spamhaus.org"
+
+        # reputation/scoring pages
+        # score.senderscore.com
+
+        # whitelists
+    CONF_WHITELISTS="
+        dwl.dnswl.org
+        list.dnswl.org
+        vouch.dwl.spamhaus.org
+        swl.spamhaus.org
+        wl.mailspike.net
+        eswlrev.dnsbl.rediris.es
+        mtawlrev.dnsbl.rediris.es
+        wbl.triumf.ca
+        whitelist.rbl.ispa.at
+        whitelist.surriel.com
+        white.uribl.com
+        whitelist.sci.kun.nl
+        ips.whitelisted.org
+        wl.nszones.com
+        dnswl.inps.de
+        dnswl.spfbl.net
+        "
 
 #~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ }
 

--- a/blcheck
+++ b/blcheck
@@ -28,9 +28,10 @@
 # description       : Test any domain against more then 100 black lists.
 # author            : Intellex
 # contributors      : Darko Poljak
-# date              : 2016-03-18
+# date              : 2020-01-23
 # version           : 0.6.0
 # usage             : blcheck [options] <domain_or_ip>
+# reference         : http://multirbl.valli.org/list/
 #
 # =============================================================================
 
@@ -43,124 +44,353 @@
 
     # Blacklists to check
     CONF_BLACKLISTS="
-        0spam-killlist.fusionzero.com
-        0spam.fusionzero.com
-        access.redhawk.org
-        all.rbl.jp
-        all.spam-rbl.fr
-        all.spamrats.com
-        aspews.ext.sorbs.net
-        b.barracudacentral.org
-        backscatter.spameatingmonkey.net
-        badnets.spameatingmonkey.net
-        bb.barracudacentral.org
-        bl.drmx.org
-        bl.konstant.no
-        bl.nszones.com
-        bl.spamcannibal.org
-        bl.spameatingmonkey.net
-        bl.spamstinks.com
-        black.junkemailfilter.com
-        blackholes.five-ten-sg.com
-        blacklist.sci.kun.nl
+        whitelist.rbl.ispa.at
+        t3direct.dnsbl.net.au
+        ucepn.dnsbl.net.au
+        wpbl.dnsbl.net.au
+        bl.reynolds.net.au
+        bl.mav.com.br
+        openproxy.bls.digibase.ca
+        proxyabuse.bls.digibase.ca
+        spambot.bls.digibase.ca
+        probes.dnsbl.net.auproxy.bl.gweep.ca
+        rbl2.triumf.ca
+        wbl.triumf.ca
+        ipbl.zeustracker.abuse.ch
+        uribl.zeustracker.abuse.ch
+        spamrbl.imp.ch
+        wormrbl.imp.ch
+        rbl.lugh.ch
+        dnsrbl.swinog.ch
+        uribl.swinog.ch
         blacklist.woody.ch
+        ipv6.blacklist.woody.ch
+        uri.blacklist.woody.ch
+        block.ascams.com
+        superblock.ascams.com
+        rbl.blockedservers.com
+        netscan.rbl.blockedservers.com
+        spam.rbl.blockedservers.com
+        list.blogspambl.com
+        dnsbl1.dnsbl.borderware.com
+        dnsbl2.dnsbl.borderware.com
+        dnsbl3.dnsbl.borderware.com
+        dul.dnsbl.borderware.com
+        csi.cloudmark.com
+        dnsbl.cobion.com
         bogons.cymru.com
-        bsb.empty.us
-        bsb.spamlookup.net
-        cart00ney.surriel.com
-        cbl.abuseat.org
-        cbl.anti-spam.org.cn
-        cblless.anti-spam.org.cn
-        cblplus.anti-spam.org.cn
-        cdl.anti-spam.org.cn
+        v4.fullbogons.cymru.com
+        v6.fullbogons.cymru.com
+        rbl.dns-servicios.com
+        0outspam.fusionzero.com
+        0spam.fusionzero.com
+        0spam-n.fusionzero.com
+        0spamtrust.fusionzero.com
+        0spamurl.fusionzero.com
+        accredit.habeas.com
+        hil.habeas.com
+        hul.habeas.com
+        sa-accredit.habeas.com
+        sohul.habeas.com
+        blacklist.hostkarma.com
+        iadb.isipp.com
+        iadb2.isipp.com
+        iddb.isipp.com
+        wadb.isipp.com
+        black.junkemailfilter.com
+        hostkarma.junkemailfilter.com
+        nobl.junkemailfilter.com
+        krn.korumail.com
+        q.mail-abuse.com
+        r.mail-abuse.com
         cidr.bl.mcafee.com
-        combined.rbl.msrbl.net
+        dnsbl.forefront.microsoft.com
+        bl.mipspace.com
+        bl.nordspam.com
+        dbl.nordspam.com
+        bl.nszones.com
+        dyn.nszones.com
+        sbl.nszones.com
+        ubl.nszones.com
+        wl.nszones.com
+        safe.dnsbl.prs.proofpoint.com
+        rbl.realtimeblacklist.com
+        mailsl.dnsbl.rjek.com
+        urlsl.dnsbl.rjek.com
+        dynip.rothen.com
+        blackholes.scconsult.com
+        reputation-domain.rbl.scrolloutf1.com
+        reputation-ip.rbl.scrolloutf1.com
+        reputation-ns.rbl.scrolloutf1.com
+        score.senderscore.com
+        bl.score.senderscore.com
+        feb.spamlab.com
+        rbl.spamlab.com
+        all.spamrats.com
+        auth.spamrats.com
+        dyna.spamrats.com
+        noptr.spamrats.com
+        spam.spamrats.com
+        rbl.suresupport.com
+        psbl.surriel.com
+        whitelist.surriel.com
+        bl.tiopan.com
+        dbl.tiopan.com
+        ubl.unsubscore.com
+        black.uribl.com
+        grey.uribl.com
+        multi.uribl.com
+        red.uribl.com
+        white.uribl.com
+        spam.dnsbl.anonmails.de
+        bl.blocklist.de
+        dnsbl.darklist.de
+        dnsbl.inps.de
+        dnswl.inps.de
+        admin.bl.kundenserver.de
+        relays.bl.kundenserver.de
+        schizo-bl.kundenserver.de
+        spamblock.kundenserver.de
+        worms-bl.kundenserver.de
+        dnsbl.madavi.de
+        torserver.tor.dnsbl.sectoor.de
+        dunk.dnsbl.tuxad.de
+        hartkore.dnsbl.tuxad.de
+        spamsources.fabel.dk
+        st.technovision.dk
+        dnsbl.abyan.es
+        eswlrev.dnsbl.rediris.es
+        mtawlrev.dnsbl.rediris.es
+        dnsbl.isx.fr
+        all.spam-rbl.fr
+        pofon.foobar.hu
+        ispmx.pofon.foobar.hu
+        uribl.pofon.foobar.hu
+        singular.ttk.pte.hu
+        blacklist.netcore.co.in
+        dnsbl.rv-soft.info
+        nana.bl.techtheft.info
+        other.bl.techtheft.info
+        robot.bl.techtheft.info
+        scanning.bl.techtheft.info
+        source.bl.techtheft.info
+        support.bl.techtheft.info
+        virus.bl.techtheft.info
+        watchlist.bl.techtheft.info
         db.wpbl.info
-        dev.null.dk
-        dialups.visi.com
+        rbl.jp
+        spamlist.or.kr
+        bl.fmb.la
+        communicado.fmb.la
+        nsbl.fmb.la
+        sa.fmb.la
+        short.fmb.la
+        contacts.abuse.net
+        dnsbl.anticaptcha.net
+        dnsbl6.anticaptcha.net
+        blacklist.mail.ops.asp.att.net
+        blacklist.sequoia.ops.asp.att.net
+        blacklist.mailrelay.att.net
+        rbl.blakjak.net
+        dul.blackhole.cantv.net
+        hog.blackhole.cantv.net
+        rhsbl.blackhole.cantv.net
+        rot.blackhole.cantv.net
+        spam.blackhole.cantv.net
+        rbl.choon.net
+        ipv6.rbl.choon.net
+        rwl.choon.net
+        ipv6.rwl.choon.net
+        dnsbl.cyberlogic.net
+        fnrbl.fast.net
+        truncate.gbudb.net
+        rbl.interserver.net
+        rbl.iprange.net
+        dnsbl.kempt.net
+        spamguard.leadmon.net
+        niprbl.mailcleaner.net
+        uribl.mailcleaner.net
+        dnsbl.mailshell.net
+        bl.mailspike.net
+        rep.mailspike.net
+        wl.mailspike.net
+        z.mailspike.net
+        ix.dnsbl.manitu.net
+        combined.rbl.msrbl.net
+        images.rbl.msrbl.net
+        phishing.rbl.msrbl.net
+        spam.rbl.msrbl.net
+        virus.rbl.msrbl.net
+        web.rbl.msrbl.net
+        relays.nether.net
+        trusted.nether.net
+        unsure.nether.net
+        dul.pacifier.net
+        all.s5h.net
+        bl.scientificspam.net
+        rhsbl.scientificspam.net
+        korea.services.net
+        dnsbl.sorbs.net
+        block.dnsbl.sorbs.net
+        exitnodes.tor.dnsbl.sectoor.dehttp.dnsbl.sorbs.net
+        dul.dnsbl.sorbs.net
+        escalations.dnsbl.sorbs.net
+        http.dnsbl.sorbs.net
+        misc.dnsbl.sorbs.net
+        new.dnsbl.sorbs.net
+        noservers.dnsbl.sorbs.net
+        old.dnsbl.sorbs.net
+        problems.dnsbl.sorbs.net
+        proxies.dnsbl.sorbs.net
+        recent.dnsbl.sorbs.net
+        relays.dnsbl.sorbs.net
+        safe.dnsbl.sorbs.net
+        smtp.dnsbl.sorbs.net
+        socks.dnsbl.sorbs.net
+        spam.dnsbl.sorbs.net
+        new.spam.dnsbl.sorbs.net
+        old.spam.dnsbl.sorbs.net
+        recent.spam.dnsbl.sorbs.net
+        web.dnsbl.sorbs.net
+        zombie.dnsbl.sorbs.net
+        aspews.ext.sorbs.net
+        l1.bbfh.ext.sorbs.net
+        l2.bbfh.ext.sorbs.net
+        l3.bbfh.ext.sorbs.net
+        l4.bbfh.ext.sorbs.net
+        rhsbl.sorbs.net
+        badconf.rhsbl.sorbs.net
+        nomail.rhsbl.sorbs.net
+        bl.spamcop.net
+        backscatter.spameatingmonkey.net
+        bl.spameatingmonkey.net
+        fresh.spameatingmonkey.net
+        fresh10.spameatingmonkey.net
+        fresh15.spameatingmonkey.net
+        fresh30.spameatingmonkey.net
+        freshzero.spameatingmonkey.net
+        bl.ipv6.spameatingmonkey.net
+        netbl.spameatingmonkey.net
+        uribl.spameatingmonkey.net
+        urired.spameatingmonkey.net
+        bsb.spamlookup.net
+        dnsbl.spfbl.net
+        dnswl.spfbl.net
+        score.spfbl.net
+        bl.suomispam.net
+        dbl.suomispam.net
+        gl.suomispam.net
+        dob.sibl.support-intelligence.net
+        srn.surgate.net
+        srnblack.surgate.net
+        rbl.tdk.net
         dnsbl-0.uceprotect.net
         dnsbl-1.uceprotect.net
         dnsbl-2.uceprotect.net
         dnsbl-3.uceprotect.net
-        dnsbl.anticaptcha.net
-        dnsbl.aspnet.hu
-        dnsbl.inps.de
-        dnsbl.justspam.org
-        dnsbl.kempt.net
-        dnsbl.madavi.de
-        dnsbl.rizon.net
-        dnsbl.rv-soft.info
-        dnsbl.rymsho.ru
-        dnsbl.sorbs.net
+        all.rbl.webiron.net
+        babl.rbl.webiron.net
+        cabl.rbl.webiron.net
+        crawler.rbl.webiron.net
+        stabl.rbl.webiron.net
         dnsbl.zapbl.net
-        dnsrbl.swinog.ch
-        dul.pacifier.net
-        dyn.nszones.com
-        dyna.spamrats.com
-        fnrbl.fast.net
-        fresh.spameatingmonkey.net
-        hostkarma.junkemailfilter.com
-        images.rbl.msrbl.net
-        ips.backscatterer.org
-        ix.dnsbl.manitu.net
-        korea.services.net
-        l2.bbfh.ext.sorbs.net
-        l3.bbfh.ext.sorbs.net
-        l4.bbfh.ext.sorbs.net
-        list.bbfh.org
-        list.blogspambl.com
-        mail-abuse.blacklist.jippg.org
-        netbl.spameatingmonkey.net
-        netscan.rbl.blockedservers.com
-        no-more-funn.moensted.dk
-        noptr.spamrats.com
+        rhsbl.zapbl.net
+        rbl.zenon.net
+        dnsbl.beetjevreemd.nl
+        bitonly.dnsbl.bit.nl
+        virbl.bit.nl
+        blacklist.sci.kun.nl
+        whitelist.sci.kun.nl
+        blackholes.tepucom.nl
+        bl.konstant.no
+        bl.0spam.org
+        nbl.0spam.org
+        url.0spam.org
+        cbl.abuseat.org
         orvedb.aupads.org
-        pbl.spamhaus.org
-        phishing.rbl.msrbl.net
-        pofon.foobar.hu
-        psbl.surriel.com
-        rbl.abuse.ro
-        rbl.blockedservers.com
-        rbl.dns-servicios.com
-        rbl.efnet.org
-        rbl.efnetrbl.org
-        rbl.iprange.net
-        rbl.schulte.org
-        rbl.talkactive.net
-        rbl2.triumf.ca
         rsbl.aupads.org
-        sbl-xbl.spamhaus.org
-        sbl.nszones.com
-        sbl.spamhaus.org
-        short.rbl.jp
-        spam.dnsbl.anonmails.de
-        spam.pedantic.org
-        spam.rbl.blockedservers.com
-        spam.rbl.msrbl.net
-        spam.spamrats.com
-        spamrbl.imp.ch
-        spamsources.fabel.dk
-        st.technovision.dk
-        tor.dan.me.uk
-        tor.dnsbl.sectoor.de
+        ips.backscatterer.org
+        b.barracudacentral.org
+        bb.barracudacentral.org
+        list.bbfh.org
+        plus.bondedsender.org
+        query.bondedsender.org
+        dnsblchile.org
+        dnsrbl.org
+        dwl.dnswl.org
+        list.dnswl.org
+        bl.drmx.org
+        dnsbl.dronebl.org
+        rbl.efnet.org
         tor.efnet.org
-        torexit.dan.me.uk
-        truncate.gbudb.net
-        ubl.unsubscore.com
-        uribl.spameatingmonkey.net
-        urired.spameatingmonkey.net
-        virbl.dnsbl.bit.nl
-        virus.rbl.jp
-        virus.rbl.msrbl.net
-        vote.drbl.caravan.ru
-        vote.drbl.gremlin.ru
-        web.rbl.msrbl.net
-        work.drbl.caravan.ru
-        work.drbl.gremlin.ru
-        wormrbl.imp.ch
+        rbl.efnetrbl.org
+        dnsbl.rangers.eu.org
+        dnsbl.httpbl.org
+        mail-abuse.blacklist.jippg.org
+        dnsbl.justspam.org
+        bl.mailspike.org
+        bl.nosolicitado.org
+        bl.worst.nosolicitado.org
+        dnsbl.openresolvers.org
+        spam.pedantic.org
+        access.redhawk.org
+        abuse.rfc-clueless.org
+        bogusmx.rfc-clueless.org
+        dsn.rfc-clueless.org
+        elitist.rfc-clueless.org
+        fulldom.rfc-clueless.org
+        postmaster.rfc-clueless.org
+        whois.rfc-clueless.org
+        public.sarbl.org
+        rbl.schulte.org
+        sbl.spamdown.org
+        dbl.spamhaus.org
+        vouch.dwl.spamhaus.org
+        pbl.spamhaus.org
+        sbl.spamhaus.org
+        sbl-xbl.spamhaus.org
+        swl.spamhaus.org
         xbl.spamhaus.org
-        zen.spamhaus.org"
+        zen.spamhaus.org
+        abuse.surbl.org
+        cr.surbl.org
+        multi.surbl.org
+        mw.surbl.org
+        dnsbl.tornevall.org
+        opm.tornevall.org
+        free.v4bl.org
+        ip.v4bl.org
+        ips.whitelisted.org
+        dnsbl.calivent.com.pe
+        forbidden.icm.edu.pl
+        dyn.rbl.polspam.pl
+        lblip4.rbl.polspam.pl
+        lblip6.rbl.polspam.pl
+        rblip4.rbl.polspam.pl
+        rblip6.rbl.polspam.pl
+        rhsbl.rbl.polspam.pl
+        rbl.abuse.ro
+        uribl.abuse.ro
+        vote.drbl.caravan.ru
+        work.drbl.caravan.ru
+        vote.drbl.gremlin.ru
+        work.drbl.gremlin.ru
+        dul.dnsbl.sorbs.netdul.ru
+        bl.shlink.orgdul.ru
+        rbl.rbldns.ru
+        dnsbl.rymsho.ru
+        rhsbl.rymsho.ru
+        netblockbl.spamgrouper.to
+        dnsbl.mcu.edu.tw
+        dnsbl.net.ua
+        rbl.fasthosts.co.uk
+        torexit.dan.me.uk
+        bsb.empty.us
+        88.blocklist.zap"
 
+        # the following blacklists only take domain names (not IPs)
+        # no solution to that, yet
+        # dbl.spamhaus.org
 
 #~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ }
 
@@ -256,6 +486,25 @@
         fi
     }
 
+    # Result info for IP
+    text() {
+
+        # IP already?
+        IP=$(echo "$1" | grep "^$REGEX_IP$")
+        if [ "$IP" ]; then
+            echo "$IP"
+
+        # Resolve domain
+        else
+
+            TYPE="txt"
+            case "$CMD" in
+                $CMD_DIG ) "$CMD" $DNSSERVER +short -t "$TYPE" +time=$CONF_DNS_DURATION +tries=$CONF_DNS_TRIES "$1" ;;
+                $CMD_HOST ) "$CMD" -t "$TYPE" -W $CONF_DNS_DURATION -R $CONF_DNS_TRIES "$1" $DNSSERVER | tail -n1 ;;
+            esac
+        fi
+    }
+
     # Load the blacklist from file
     loadBlacklists() {
 
@@ -281,7 +530,7 @@ If the IP is supplied, the PTR check cannot be executed and will be skipped.
 -l file     Load blacklists from file, separated by space or new line
 -c          Warn if the top level domain of the blacklist has expired
 -v          Verbose mode, can be used multiple times (up to -vvv)
--q          Quiet modem with absolutely no output (useful for scripts)
+-q          Quiet mode with absolutely no output (useful for scripts)
 -p          Plain text output (no coloring, no interactive status)
 -h          The help you are just reading
 
@@ -480,6 +729,7 @@ for BL in $BLACKLISTS; do
         if [ $VERBOSE -ge 1 ]; then
             if test -z "$PLAIN"; then printf "\r"; fi
             printf "%s%sinvalid response (%s)%s\n" "$YELLOW" "$PREFIX" "$RESPONSE" "$CLEAR";
+            printf "%s%${#PREFIX}s%s%s\n" "$YELLOW" "TXT: " "$(text "${TEST}")" "$CLEAR";
         fi;
         INVALID=$((INVALID + 1))
 
@@ -488,6 +738,7 @@ for BL in $BLACKLISTS; do
         if [ $VERBOSE -ge 1 ]; then
             if test -z "$PLAIN"; then printf "\r"; fi
             printf "%s%sblacklisted (%s)%s\n" "$RED" "$PREFIX" "$RESPONSE" "$CLEAR";
+            printf "%s%${#PREFIX}s%s%s\n" "$RED" "TXT: " "$(text "${TEST}")" "$CLEAR";
         elif [ $VERBOSE -ge 0 ]; then
             if test -z "$PLAIN"; then printf "\r                                                          "; printf "\r"; fi
             printf "%s%s%s : %s\n" "$RED" "$BL" "$CLEAR" "$RESPONSE"
@@ -514,4 +765,3 @@ if [ $VERBOSE -ge 0 ]; then
 fi
 
 exit $FAILED;
-

--- a/blcheck
+++ b/blcheck
@@ -25,25 +25,41 @@
 # =============================================================================
 #
 # title             : blcheck
-# description       : Test any domain against more then 100 black lists.
+# description       : Test any domain against more than 100 black lists.
 # author            : Intellex
 # contributors      : Darko Poljak
 # date              : 2020-01-23
 # version           : 0.6.0
 # usage             : blcheck [options] <domain_or_ip>
 # reference         : http://multirbl.valli.org/list/
+# code style        : https://google.github.io/styleguide/shell.xml
 #
 # =============================================================================
 
 # Config {
-
 
     # How many tries and for how long to wait for DNS queries
     CONF_DNS_TRIES=2
     CONF_DNS_DURATION=3
 
     # Blacklists to check
+    # Example formats:
+    # - General format
+    #   {ip_or_domain}={filter}#{type}
+    # - IP based blacklist (default DNSBL, any valid return code will match)
+    #   black.list.com
+    # - IP based blacklist
+    #   black.list.com#DNSBL
+    # - IP based whitelist
+    #   white.list.com#DNSWL
+    # - URI based blacklist
+    #   uri.list.com#URIBL
+    # - Regexp defined return code, only a match will qualify for list. Here it is 127.0.0.2 and 127.0.0.3
+    #   black.list.com=127\.0\.0\.[23]
+    # - Regexp defined return code for a URI based blacklist
+    #   black.list.com=127\.0\.[0-9]+\.0#URIBL
     CONF_BLACKLISTS="
+        whitelist.rbl.ispa.at#DNSWL
         t3direct.dnsbl.net.au
         ucepn.dnsbl.net.au
         wpbl.dnsbl.net.au
@@ -54,6 +70,7 @@
         spambot.bls.digibase.ca
         probes.dnsbl.net.auproxy.bl.gweep.ca
         rbl2.triumf.ca
+        wbl.triumf.ca#DNSWL
         ipbl.zeustracker.abuse.ch
         uribl.zeustracker.abuse.ch
         spamrbl.imp.ch
@@ -105,10 +122,12 @@
         dnsbl.forefront.microsoft.com
         bl.mipspace.com
         bl.nordspam.com
+        dbl.nordspam.com#URIBL
         bl.nszones.com
         dyn.nszones.com
         sbl.nszones.com
         ubl.nszones.com
+        wl.nszones.com#DNSWL
         safe.dnsbl.prs.proofpoint.com
         rbl.realtimeblacklist.com
         mailsl.dnsbl.rjek.com
@@ -128,16 +147,20 @@
         spam.spamrats.com
         rbl.suresupport.com
         psbl.surriel.com
+        whitelist.surriel.com#DNSWL
         bl.tiopan.com
+        dbl.tiopan.com#URIBL
         ubl.unsubscore.com
         black.uribl.com
         grey.uribl.com
         multi.uribl.com
         red.uribl.com
+        white.uribl.com#DNSWL
         spam.dnsbl.anonmails.de
         bl.blocklist.de
         dnsbl.darklist.de
         dnsbl.inps.de
+        dnswl.inps.de#DNSWL
         admin.bl.kundenserver.de
         relays.bl.kundenserver.de
         schizo-bl.kundenserver.de
@@ -150,6 +173,8 @@
         spamsources.fabel.dk
         st.technovision.dk
         dnsbl.abyan.es
+        eswlrev.dnsbl.rediris.es#DNSWL
+        mtawlrev.dnsbl.rediris.es#DNSWL
         dnsbl.isx.fr
         all.spam-rbl.fr
         pofon.foobar.hu
@@ -174,7 +199,6 @@
         nsbl.fmb.la
         sa.fmb.la
         short.fmb.la
-        contacts.abuse.net
         dnsbl.anticaptcha.net
         dnsbl6.anticaptcha.net
         blacklist.mail.ops.asp.att.net
@@ -202,6 +226,7 @@
         dnsbl.mailshell.net
         bl.mailspike.net
         rep.mailspike.net
+        wl.mailspike.net#DNSWL
         z.mailspike.net
         ix.dnsbl.manitu.net
         combined.rbl.msrbl.net
@@ -264,7 +289,9 @@
         bsb.spamlookup.net
         dnsbl.spfbl.net
         score.spfbl.net
+        dnswl.spfbl.net#DNSWL
         bl.suomispam.net
+        dbl.suomispam.net#URIBL
         gl.suomispam.net
         dob.sibl.support-intelligence.net
         srn.surgate.net
@@ -286,6 +313,7 @@
         bitonly.dnsbl.bit.nl
         virbl.bit.nl
         blacklist.sci.kun.nl
+        whitelist.sci.kun.nl#DNSWL
         blackholes.tepucom.nl
         bl.konstant.no
         bl.0spam.org
@@ -302,6 +330,8 @@
         query.bondedsender.org
         dnsblchile.org
         dnsrbl.org
+        dwl.dnswl.org#DNSWL
+        list.dnswl.org#DNSWL
         bl.drmx.org
         dnsbl.dronebl.org
         rbl.efnet.org
@@ -327,9 +357,12 @@
         public.sarbl.org
         rbl.schulte.org
         sbl.spamdown.org
+        dbl.spamhaus.org#URIBL
+        vouch.dwl.spamhaus.org#DNSWL
         pbl.spamhaus.org
         sbl.spamhaus.org
         sbl-xbl.spamhaus.org
+        swl.spamhaus.org#DNSWL
         xbl.spamhaus.org
         zen.spamhaus.org
         abuse.surbl.org
@@ -340,6 +373,7 @@
         opm.tornevall.org
         free.v4bl.org
         ip.v4bl.org
+        ips.whitelisted.org#DNSWL
         dnsbl.calivent.com.pe
         forbidden.icm.edu.pl
         dyn.rbl.polspam.pl
@@ -356,7 +390,7 @@
         work.drbl.gremlin.ru
         dul.dnsbl.sorbs.netdul.ru
         bl.shlink.orgdul.ru
-        rbl.rbldns.ru
+     ###rbl.rbldns.ru
         dnsbl.rymsho.ru
         rhsbl.rymsho.ru
         netblockbl.spamgrouper.to
@@ -367,36 +401,20 @@
         bsb.empty.us
         88.blocklist.zap"
 
-        # the following blacklists only take domain names (not IPs)
-        # no solution to that, yet
-    CONF_DOMAINLISTS="
-        dbl.nordspam.com
-        dbl.tiopan.com
-        dbl.suomispam.net
-        dbl.spamhaus.org"
 
         # reputation/scoring pages
         # score.senderscore.com
 
-        # whitelists
-    CONF_WHITELISTS="
-        dwl.dnswl.org
-        list.dnswl.org
-        vouch.dwl.spamhaus.org
-        swl.spamhaus.org
-        wl.mailspike.net
-        eswlrev.dnsbl.rediris.es
-        mtawlrev.dnsbl.rediris.es
-        wbl.triumf.ca
-        whitelist.rbl.ispa.at
-        whitelist.surriel.com
-        white.uribl.com
-        whitelist.sci.kun.nl
-        ips.whitelisted.org
-        wl.nszones.com
-        dnswl.inps.de
-        dnswl.spfbl.net
-        "
+    CONF_BLACKLISTS_TEST="
+        rbl.rbldns.ru
+        rbl.rbldns.ru=127\.0\.0\.1
+        rbl.rbldns.ru#DNSWL
+        black.list.com=127.0.[0-9]+.0#URIBL
+        dbl.spamhaus.org#URIBL
+        t3direct.dnsbl.net.au=127\.0\.0\.1#DNSWL
+        t3direct.dnsbl.net.au#BLA
+        t3direct.dnsbl.net.au%127\.0\.0\.1#DNSWL"
+
 
 #~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ }
 
@@ -407,6 +425,7 @@
     REGEX_IP='\([0-9]\{1,3\}\)\.\([0-9]\{1,3\}\)\.\([0-9]\{1,3\}\)\.\([0-9]\{1,3\}\)'
     REGEX_DOMAIN='\([a-zA-Z0-9]\+\(-[a-zA-Z0-9]\+\)*\.\)\+[a-zA-Z]\{2,\}'
     REGEX_TDL='\([a-zA-Z0-9]\+\(-[a-zA-Z0-9]\+\)*\.\)[a-zA-Z]\{2,\}$'
+    REGEX_LIST='^[ \\t]*([^=#]+)(=(([^#])+))?(#(DNSBL|DNSWL|URIBL))?[ \\t]*$'
 
     # Colors
     if [[ $- == *i* ]]; then
@@ -434,6 +453,7 @@
     #SPINNER="◴◷◶◵"
     #SPINNER="◐◓◑◒"
 
+    VERBOSE=0
 
 #~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ }
 
@@ -441,9 +461,8 @@
 # Macros {
 
     # Verbose printing
-    VERBOSE=0
     info() {
-        if [ $VERBOSE -ge "$1" ]; then
+        if [[ ${VERBOSE} -ge "$1" ]]; then
             echo "$2"
         fi
     }
@@ -458,55 +477,54 @@
     progress() {
 
         # Bar
-        x=$(($1 % ${#SPINNER} + 1))
-        BAR=$(echo $SPINNER | awk "{ print substr(\$0, ${x}, 1) }")
-        if test -z "$PLAIN"; then
+        local x=$(($1 % ${#SPINNER} + 1))
+        local BAR=$(echo ${SPINNER} | awk "{ print substr(\$0, ${x}, 1) }")
+        if [[ -z "${PLAIN}" ]]; then
             printf "\r ";
         fi
 
         # BAR as printf arg so that backslash will be litteraly interpreted
-        printf "[ %s %3s%% ] checking... %4s / $2  " "$BAR" $(($1 * 100 / $2)) "$1";
+        printf "[ %s %3s%% ] checking... %4s / $2  " "${BAR}" $(($1 * 100 / $2)) "$1";
     }
 
     # Resolve the IP
     resolve() {
 
         # IP already?
-        IP=$(echo "$1" | grep "^$REGEX_IP$")
-        if [ "$IP" ]; then
-            echo "$IP"
+        local IP=$(echo "$1" | grep "^${REGEX_IP}$")
+        if [[ "${IP}" ]]; then
+            echo "${IP}"
 
         # Resolve domain
         else
 
             # Handle special resolve types
             case "$2" in
-                "ns" ) TYPE="ns"; REGEX="$REGEX_DOMAIN\.$";;
-                   * ) TYPE="a";  REGEX="$REGEX_IP$";;
+                "ns" ) TYPE="ns"; REGEX="${REGEX_DOMAIN}\.$";;
+                   * ) TYPE="a";  REGEX="${REGEX_IP}$";;
             esac
 
-            case "$CMD" in
-                $CMD_DIG ) "$CMD" $DNSSERVER +short -t "$TYPE" +time=$CONF_DNS_DURATION +tries=$CONF_DNS_TRIES "$1" | grep -om 1 "$REGEX";;
-                $CMD_HOST ) "$CMD" -t "$TYPE" -W $CONF_DNS_DURATION -R $CONF_DNS_TRIES "$1" $DNSSERVER | tail -n1 | grep -om 1 "$REGEX";;
+            case "${CMD}" in
+                ${CMD_DIG} ) "${CMD}" ${DNSSERVER} +short -t "${TYPE}" +time=${CONF_DNS_DURATION} +tries=${CONF_DNS_TRIES} "$1" | grep -om 1 "${REGEX}";;
+                ${CMD_HOST} ) "${CMD}" -t "${TYPE}" -W ${CONF_DNS_DURATION} -R ${CONF_DNS_TRIES} "$1" ${DNSSERVER} | tail -n1 | grep -om 1 "${REGEX}";;
             esac
         fi
     }
 
     # Result info for IP
     text() {
-
         # IP already?
-        IP=$(echo "$1" | grep "^$REGEX_IP$")
-        if [ "$IP" ]; then
-            echo "$IP"
+        local IP=$(echo "$1" | grep "^${REGEX_IP}$")
+        if [[ -n "${IP}" ]]; then
+            echo "${IP}"
 
         # Resolve domain
         else
 
-            TYPE="txt"
-            case "$CMD" in
-                $CMD_DIG ) "$CMD" $DNSSERVER +short -t "$TYPE" +time=$CONF_DNS_DURATION +tries=$CONF_DNS_TRIES "$1" ;;
-                $CMD_HOST ) "$CMD" -t "$TYPE" -W $CONF_DNS_DURATION -R $CONF_DNS_TRIES "$1" $DNSSERVER | tail -n1 ;;
+            local TYPE="txt"
+            case "${CMD}" in
+                ${CMD_DIG} ) "${CMD}" ${DNSSERVER} +short -t "${TYPE}" +time=${CONF_DNS_DURATION} +tries=${CONF_DNS_TRIES} "$1" ;;
+                ${CMD_HOST} ) "${CMD}" -t "${TYPE}" -W ${CONF_DNS_DURATION} -R ${CONF_DNS_TRIES} "$1" ${DNSSERVER} | tail -n1 ;;
             esac
         fi
     }
@@ -515,9 +533,9 @@
     loadBlacklists() {
 
         # Make sure the file is readable
-        if [ ! "$1" ]; then
+        if [[ -z "$1" ]]; then
             error "Option -l requires an additional parameter";
-        elif [ ! -r $1 ]; then
+        elif [[ ! -r $1 ]]; then
             error "File $1 cannot be opened for reading, make sure it exists and that you have appropriate privileges"
         fi
 
@@ -551,21 +569,21 @@ HELP
 
 # Parse the params
 while getopts :vqphcl:d: arg; do
-    case "$arg" in
-        d) DNSSERVER=$OPTARG;;
-        l) loadBlacklists $OPTARG;;
+    case "${arg}" in
+        d) DNSSERVER="${OPTARG}";;
+        l) loadBlacklists "${OPTARG}";;
         c) VERIFY_BL=TRUE;;
-        v) VERBOSE=$(( (VERBOSE + 1) % 4));;
+        v) VERBOSE=$((VERBOSE + 1));;
         q) VERBOSE=-1;;
         p) PLAIN=1 RED="" GREEN="" YELLOW="" CLEAR="" ;;
         h) showHelp;;
-        ?) error "Unknown option $OPTARG";;
+        ?) error "Unknown option ${OPTARG}";;
     esac
 done
 shift $((OPTIND - 1))
 
 # Get the domain
-if [ $# -eq 0 ]; then
+if [[ $# -eq 0 ]]; then
     echo "Missing target domain or IP."
     showHelp
 fi
@@ -577,197 +595,262 @@ shopt -s xpg_echo
 
 # Get the command we will use: dig or host
 CMD_DIG=$(which dig)
-CMD_HOST=$(which host)
-if [ "$CMD_DIG" ]; then
-    if [[ $DNSSERVER ]]; then
-        DNSSERVER="@$DNSSERVER"
+if [[ "${CMD_DIG}" ]]; then
+    if [[ -n "${DNSSERVER}" ]]; then
+        DNSSERVER="@${DNSSERVER}"
     fi
-    CMD=$CMD_DIG
-elif [ "$CMD_HOST" ]; then
-    CMD=$CMD_HOST
+    CMD=${CMD_DIG}
+else
+    CMD_HOST=$(which host)
+    if [[ "${CMD_HOST}" ]]; then
+        CMD=${CMD_HOST}
+    fi
 fi
-if [ ! "$CMD" ]; then
+if [[ -z "${CMD}" ]]; then
     error "Either dig or host command is required."
 fi
-info 3 "Using $CMD to reslove DNS queries"
+info 3 "Using ${CMD} to reslove DNS queries"
 
 # Parse IP
-IP=$(resolve "$TARGET")
-if [ ! "$IP" ]; then
-    error "No DNS record found for $TARGET"
-elif [ "$IP" != "$TARGET" ]; then
-    DOMAIN=$TARGET
-    info 2 "Using $TARGET for target, resolved to $IP"
+IP=$(resolve "${TARGET}")
+if [[ -z "${IP}" ]]; then
+    error "No DNS record found for ${TARGET}"
+elif [[ "${IP}" != "${TARGET}" ]]; then
+    DOMAIN=${TARGET}
+    info 2 "Using ${TARGET} for target, resolved to ${IP}"
+    TARGET_TYPE="domain"
 else
-    info 3 "Using $TARGET for target"
+    info 3 "Using ${TARGET} for target"
+    TARGET_TYPE="ip"
 fi
 
 # Reverse the IP
-REVERSED=$(echo "$IP" | sed -ne "s~^$REGEX_IP$~\4.\3.\2.\1~p")
-info 3 "Using $REVERSED for reversed IP"
+REVERSED=$(echo "${IP}" | sed -ne "s~^${REGEX_IP}$~\4.\3.\2.\1~p")
+info 3 "Using ${REVERSED} for reversed IP"
 
 # Get the PTR
 info 3 "Checking the PTR record"
-case "$CMD" in
-    $CMD_DIG ) PTR=$("$CMD" $DNSSERVER +short -x "$IP" | sed s/\.$//);;
-    $CMD_HOST ) PTR=$("$CMD" "$IP" $DNSSERVER | tail -n1 | grep -o '[^ ]\+$' | sed s/\.$//)
+case "${CMD}" in
+    ${CMD_DIG} ) PTR=$("${CMD}" ${DNSSERVER} +short -x "${IP}" | sed s/\.$//);;
+    ${CMD_HOST} ) PTR=$("${CMD}" "${IP}" ${DNSSERVER} | tail -n1 | grep -o '[^ ]\+$' | sed s/\.$//)
 esac
 
 # Validate PTR
-if [ ! "$PTR" ]; then
+if [[ -z "${PTR}" ]]; then
     info 0 "${YELLOW}Warning: PTR lookup failed${CLEAR}"
 
 else
 
     # Match against supplied domain
-    info 1 "PTR resolves to $PTR"
-    if [ "$DOMAIN" ]; then
-        if [ "$DOMAIN" != "$PTR" ]; then
-            info 0 "${YELLOW}Warning: PTR record does not match supplied domain: $TARGET != $PTR${CLEAR}"
+    info 1 "PTR resolves to ${PTR}"
+    if [[ -n "${DOMAIN}" ]]; then
+        if [[ "${DOMAIN}" != "${PTR}" ]]; then
+            info 0 "${YELLOW}Warning: PTR record does not match supplied domain: ${TARGET} != ${PTR}${CLEAR}"
         else
-            info 1 "${GREEN}PTR record matches supplied domain $PTR${CLEAR}"
+            info 1 "${GREEN}PTR record matches supplied domain ${PTR}${CLEAR}"
         fi
     fi
 fi
 
 # Filter out the blacklists
 BLACKLISTS=""
-for BL in $CONF_BLACKLISTS; do
-    if [ "$BL" ]; then
-
-        # Make sure the domain is a proper one
-        DOMAIN=$(echo "$BL" | sed -e 's/^[ \t]*//' | grep ^"$REGEX_DOMAIN"$)
-        if [ ! "$DOMAIN" ]; then
-            info 0 "${YELLOW}Warning: blacklist '$BL' is not valid and will be ignored${CLEAR}"
-
-        else
-
-            # It is a proper blacklist
-            if [ "$BLACKLISTS" ]; then
-                BLACKLISTS=$(echo "$BLACKLISTS\n$DOMAIN")
+COUNT_DNSBL=0
+COUNT_DNSWL=0
+COUNT_URIBL=0
+COUNT=0
+for BL in ${CONF_BLACKLISTS}; do
+    if [[ "${BL}" ]]; then
+        if [[ ${BL} =~ ${REGEX_LIST} ]]; then
+            DOMAIN="${BASH_REMATCH[1]}"
+            if [[ -n "${BASH_REMATCH[3]}" ]]; then
+                FILTER="${BASH_REMATCH[3]}"
             else
-                BLACKLISTS="$BL"
+                FILTER='127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})'
             fi
+            if [[ -n "${BASH_REMATCH[6]}" ]]; then
+                TYPE="${BASH_REMATCH[6]}"
+            else
+                TYPE='DNSBL'
+            fi
+
+            # Make sure the domain is a proper one
+            TMP=$(echo "${DOMAIN}" | sed -e 's/^[ \t]*//' | grep ^"${REGEX_DOMAIN}"$)
+            if [[ -z "${TMP}" ]]; then
+               info 0 "${YELLOW}Warning: domain '${DOMAIN}' is not valid and will be ignored${CLEAR}"
+
+            else
+                if [[ "${TARGET_TYPE}" == 'ip' && "${TYPE}" == 'URIBL' ]]; then
+                    info 0 "${GREEN}Notice: URIBL entry '${DOMAIN}' will be ignore, because ${TARGET} is an IP address${CLEAR}"
+                else
+                case "${TYPE}" in
+                    "DNSBL") COUNT_DNSBL=$((COUNT_DNSBL + 1)) ;;
+                    "DNSWL") COUNT_DNSWL=$((COUNT_DNSWL + 1)) ;;
+                    "URIBL") COUNT_URIBL=$((COUNT_URIBL + 1)) ;;
+                esac
+                COUNT=$((COUNT + 1))
+
+                # It is a proper blacklist
+                if [[ "${BLACKLISTS}" ]]; then
+                    BLACKLISTS=$(echo "${BLACKLISTS}\n${DOMAIN}=${FILTER}#${TYPE}")
+                else
+                    BLACKLISTS="${DOMAIN}=${FILTER}#${TYPE}"
+                fi
+            fi
+            fi
+        else
+            info 0 "${YELLOW}Warning: list entry '${BL}' is not valid and will be ignored${CLEAR}"
         fi
     fi
 done
 
 # Make sure we have at least one blacklist
-COUNT=$(($(echo "$BLACKLISTS" | wc -l)))
-if [ ! "$BLACKLISTS" ] || [ "$COUNT" -eq 0 ]; then
+if [[ "${COUNT}" -eq 0 ]]; then
     error "No blacklists have been specified"
 fi
-info 1 "Matching against $COUNT blacklists"
+info 1 "Matching against ${COUNT} entries:"
+info 1 "  - ${COUNT_DNSBL} DNS blacklists"
+info 1 "  - ${COUNT_DNSWL} DNS whitelists"
+info 1 "  - ${COUNT_URIBL} URI blacklists"
 
 # Initialize the counters
 INVALID=0
 PASSED=0
 FAILED=0
+WHITE=0
 
-# Interate over all blacklists
+# Iterate over all blacklists
 I=0;
-for BL in $BLACKLISTS; do
+for BL in ${BLACKLISTS}; do
     PREFIX=
     I=$((I + 1))
 
-    # What should we test
-    TEST="$REVERSED.$BL."
+    # Parse list entry
+    if [[ ! ${BL} =~ ${REGEX_LIST} ]]; then
+        error "List entry ${BL} broken"
+    fi
+    DOMAIN="${BASH_REMATCH[1]}"
+    FILTER="${BASH_REMATCH[3]}"
+    TYPE="${BASH_REMATCH[6]}"
 
-    # Make sure the info is shown if we are cheking the servers
-    if [ "$VERIFY_BL" ] && [ $VERBOSE -lt 1 ]; then
+
+
+    # What should we test
+    if [[ "${TYPE}" != "URIBL" ]]; then
+        # IP based test
+        TEST="${REVERSED}.${DOMAIN}."
+    else
+        # Domain name based test (URI)
+        TEST="${TARGET}.${DOMAIN}."
+    fi
+
+
+    # Make sure the info is shown if we are checking the servers
+    if [[ "${VERIFY_BL}" && "${VERBOSE}" -lt 1 ]]; then
         VERBOSE=1
     fi
 
     # For verbose output
-    if [ $VERBOSE -ge 1 ]; then
+    if [[ "${VERBOSE}" -ge 1 ]]; then
 
         # Show percentage
         STATUS=$(printf " %3s" $((I * 100 / COUNT)))
-        STATUS="$STATUS%% "
+        STATUS="${STATUS}%% "
 
         # Show additional info
-        if [ $VERBOSE -ge 3 ]; then
-            PREFIX=$(printf "%-60s" "$TEST")
+        if [[ "${VERBOSE}" -ge 3 ]]; then
+            PREFIX=$(printf "%-60s" "${TEST}")
         else
-            PREFIX=$(printf "%-50s" "$BL")
+            PREFIX=$(printf "%-50s" "${DOMAIN}")
         fi
 
-        PREFIX="$STATUS $PREFIX"
-        if test -z "$PLAIN"; then
-            printf "%s \b" "$PREFIX"
+        PREFIX="${STATUS} ${PREFIX}"
+        if [[ -z "${PLAIN}" ]]; then
+            printf "%s \b" "${PREFIX}"
         fi
 
-    elif [ $VERBOSE -ge 0 ]; then
-        if test -z "$PLAIN"; then
-            progress "$I" "$COUNT"
+    elif [[ "${VERBOSE}" -ge 0 ]]; then
+        if [[ -z "${PLAIN}" ]]; then
+            progress "${I}" "${COUNT}"
         fi
     fi
 
     # Get the status
-    RESPONSE=$(resolve "$TEST")
-    START=$(echo "$RESPONSE" | cut -c1-4)
+    RESPONSE=$(resolve "${TEST}")
 
     # Not blacklisted
-    if [ ! "$RESPONSE" ]; then
+    if [[ -z "${RESPONSE}" ]]; then
 
         # Make sure the server is viable
         ERROR=""
-        if [ "$VERIFY_BL" ]; then
-            TDL=$(echo "$BL" | grep -om 1 '\([a-zA-Z0-9]\+\(-[a-zA-Z0-9]\+\)*\.\)[a-zA-Z]\{2,\}$')
-            if [ ! "$(resolve "$TDL" ns)" ]; then
-                if test -z "$PLAIN"; then printf "\r"; fi
-                printf "%s%sUnreachable server%s\n" "$YELLOW" "$PREFIX" "$CLEAR";
+        if [[ "${VERIFY_BL}" ]]; then
+            TDL=$(echo "${DOMAIN}" | grep -om 1 '\([a-zA-Z0-9]\+\(-[a-zA-Z0-9]\+\)*\.\)[a-zA-Z]\{2,\}$')
+            if [[ ! "$(resolve "${TDL}" ns)" ]]; then
+                if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
+                printf "%s%sUnreachable server%s\n" "${YELLOW}" "${PREFIX}" "${CLEAR}";
                 INVALID=$((INVALID + 1))
                 ERROR=TRUE
             fi
         fi
 
-        if [ ! "$ERROR" ]; then
-            if [ "$VERIFY_BL" ] || [ $VERBOSE -ge 1 ]; then
-                if test -z "$PLAIN"; then printf "\r"; fi
-                printf "%s%s✓%s\n" "$CLEAR" "$PREFIX" "$CLEAR";
+        if [[ ! "${ERROR}" ]]; then
+            if [[ -n "${VERIFY_BL}" || "${VERBOSE}" -ge 1 ]]; then
+                if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
+                printf "%s%s✓%s\n" "${CLEAR}" "${PREFIX}" "${CLEAR}";
             fi
             PASSED=$((PASSED + 1))
         fi;
 
     # Invalid response
-    elif [ "$START" != "127."  ]; then
-        if [ $VERBOSE -ge 1 ]; then
-            if test -z "$PLAIN"; then printf "\r"; fi
-            printf "%s%sinvalid response (%s)%s\n" "$YELLOW" "$PREFIX" "$RESPONSE" "$CLEAR";
-            printf "%s%${#PREFIX}s%s%s\n" "$YELLOW" "TXT: " "$(text "${TEST}")" "$CLEAR";
+    elif [[ ! "${RESPONSE}" =~ ${FILTER} ]]; then
+        if [[ "${VERBOSE}" -ge 1 ]]; then
+            if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
+            printf "%s%sinvalid response (%s)%s\n" "${YELLOW}" "${PREFIX}" "${RESPONSE}" "${CLEAR}";
+            printf "%s%${#PREFIX}s%s%s\n" "${YELLOW}" "TXT: " "$(text "${TEST}")" "${CLEAR}";
         fi;
         INVALID=$((INVALID + 1))
 
-    # Blacklisted
+    # matched
     else
-        if [ $VERBOSE -ge 1 ]; then
-            if test -z "$PLAIN"; then printf "\r"; fi
-            printf "%s%sblacklisted (%s)%s\n" "$RED" "$PREFIX" "$RESPONSE" "$CLEAR";
-            printf "%s%${#PREFIX}s%s%s\n" "$RED" "TXT: " "$(text "${TEST}")" "$CLEAR";
-        elif [ $VERBOSE -ge 0 ]; then
-            if test -z "$PLAIN"; then printf "\r                                                          "; printf "\r"; fi
-            printf "%s%s%s : %s\n" "$RED" "$BL" "$CLEAR" "$RESPONSE"
+        if [[ "${TYPE}" != "DNSWL" ]]; then
+            if [[ "${VERBOSE}" -ge 1 ]]; then
+                if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
+                printf "%s%sblacklisted (%s)%s\n" "${RED}" "${PREFIX}" "${RESPONSE}" "${CLEAR}";
+                printf "%s%${#PREFIX}s%s%s\n" "${RED}" "TXT: " "$(text "${TEST}")" "${CLEAR}";
+            elif [[ "${VERBOSE}" -ge 0 ]]; then
+                if [[ -z "${PLAIN}" ]]; then printf "\r                                                          "; printf "\r"; fi
+                printf "%s%s%s : %s\n" "${RED}" "${DOMAIN}" "${CLEAR}" "${RESPONSE}"
+            fi
+            FAILED=$((FAILED + 1))
+        else
+            if [[ "${VERBOSE}" -ge 1 ]]; then
+                if [[ -z "${PLAIN}" ]]; then printf "\r"; fi
+                printf "%s%swhitelisted (%s)%s\n" "${GREEN}" "${PREFIX}" "${RESPONSE}" "${CLEAR}";
+                printf "%s%${#PREFIX}s%s%s\n" "${GREEN}" "TXT: " "$(text "${TEST}")" "${CLEAR}";
+            elif [[ "${VERBOSE}" -ge 0 ]]; then
+                if [[ -z "${PLAIN}" ]]; then printf "\r                                                          "; printf "\r"; fi
+                printf "%s%s%s : %s\n" "${GREEN}" "${DOMAIN}" "${CLEAR}" "${RESPONSE}"
+            fi
+             WHITE=$((WHITE + 1))
         fi
-        FAILED=$((FAILED + 1))
     fi
 done
 
 # Print results
-if [ $VERBOSE -ge 0 ]; then
-    if test -z "$PLAIN"; then
+if [[ "${VERBOSE}" -ge 0 ]]; then
+    if [[ -z "${PLAIN}" ]]; then
         printf "\r                                                    \n"
     else
         printf "                                                     \n"
     fi
     echo "----------------------------------------------------------"
-    echo Results for "$TARGET"
+    echo Results for "${TARGET}"
     echo
     printf "%-15s" "Tested:";   echo "${COUNT}"
     printf "%-15s" "Passed:";   echo "${GREEN}${PASSED}${CLEAR}"
+    printf "%-15s" "Whitelisted:";  echo "${GREEN}${WHITE}${CLEAR}"
     printf "%-15s" "Invalid:";  echo "${YELLOW}${INVALID}${CLEAR}"
     printf "%-15s" "Blacklisted:";  echo "${RED}${FAILED}${CLEAR}"
     echo "----------------------------------------------------------"
 fi
 
-exit $FAILED;
+exit "${FAILED}"


### PR DESCRIPTION
The list of entries has be reworked. Old and invalid ones have been deleted, new ones added (http://multirbl.valli.org/list/) and the list itself has been reordered so same services are group together now (sorting TLD->sublevels).

The list now supports 2 new major features. One is an optional filter, which is able to differentiate between real entries/matches and errors. The second one is a type. So whitelists and URI blacklists are also supported now. Obviously a whitelist will not be counted as blacklisted, but it is a good information for the user, if this domain is whitelisted somewhere. If blcheck is called by domain name, it will also use any URIBL given to check, if the domain name is blacklisted somewhere.

Also change the coding style a little bit to be more compatible with Google's [Shell Style Guide](https://google.github.io/styleguide/shell.xml).