### PR TITLE
Remove cbl.abuseat.org

### DIFF
--- a/blcheck
+++ b/blcheck
@@ -68,7 +68,6 @@
         bsb.empty.us
         bsb.spamlookup.net
         cart00ney.surriel.com
-        cbl.abuseat.org
         cbl.anti-spam.org.cn
         cblless.anti-spam.org.cn
         cblplus.anti-spam.org.cn


### PR DESCRIPTION
Per https://www.abuseat.org/cutover.html, it's the same as Spamhaus XBL